### PR TITLE
Add `__version__` attribute to `spotter`

### DIFF
--- a/spotter/__init__.py
+++ b/spotter/__init__.py
@@ -4,4 +4,11 @@ non-uniform stellar surfaces using HEALPix and JAX.
 
 """
 
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("spotter")
+except PackageNotFoundError:
+    __version__ = "unknown"
+
 from spotter.star import Star, show, video


### PR DESCRIPTION
### Description

This PR adds a `__version__` attribute to the `spotter` module using the `importlib.metadata` approach. This enables users to programmatically access the package version.

### Changes

- Adds the following to `spotter/__init__.py`:
```python
from importlib.metadata import version, PackageNotFoundError

try:
    __version__ = version("spotter")
except PackageNotFoundError:
    __version__ = "unknown"
```

### Motivation

Fixes [#38](https://github.com/lgrcia/spotter/issues/38) by exposing the version at the module level.

### Checklist

- [x] Code runs locally
- [x] Version is accessible via `spotter.__version__`
- [x] `pytest` returns "11 passed, 9 skipped, 4 warnings"
