### PR TITLE
Added option to choose normalize or not integ spec

### DIFF
--- a/spotter/core.py
+++ b/spotter/core.py
@@ -533,7 +533,7 @@ def shifted_spectra(spectra, shift):
     return jnp.real(shifted)
 
 
-def integrated_spectrum(N, theta, phi, period, radius, wv, spectra, phase, inc):
+def integrated_spectrum(N, theta, phi, period, radius, wv, spectra, phase, inc, normalize):
     """
     Compute the integrated spectrum of a rotating star.
 
@@ -573,6 +573,9 @@ def integrated_spectrum(N, theta, phi, period, radius, wv, spectra, phase, inc):
         shift = w_shift[:, None] * wv / dw
         limb_geometry = projected * mask * limb
         spectra_shifted = shifted_spectra(spectra.T, shift)
-    return jnp.sum(spectra_shifted * limb_geometry[:, None], 0) / jnp.sum(
-        limb_geometry[:, None] * spectra.T
-    )
+        
+        if normalize:
+            integrated_spec =  jnp.sum(spectra_shifted * limb_geometry[:, None], 0) / jnp.sum(limb_geometry[:, None] * spectra.T)
+        else:
+            integrated_spec =  jnp.sum(spectra_shifted * limb_geometry[:, None], 0)
+        return integrated_spec

--- a/spotter/doppler.py
+++ b/spotter/doppler.py
@@ -15,8 +15,8 @@ from spotter import core, light_curves
 from spotter.star import Star
 
 
-@partial(jnp.vectorize, excluded=(0,), signature="()->(n)")
-def spectrum(star: Star, time: float) -> ArrayLike:
+@partial(jnp.vectorize, excluded=(0,2), signature="()->(n)")
+def spectrum(star: Star, time: float, normalize: bool) -> ArrayLike:
     """
     Compute the integrated spectrum of a rotating Star.
 
@@ -43,6 +43,7 @@ def spectrum(star: Star, time: float) -> ArrayLike:
         star.y,
         star.phase(time),
         star.inc,
+        normalize
     )
 
 


### PR DESCRIPTION
The original version of the core.integrated_spectrum() function by default normalizes the integrated spectrum. However, in certain cases when one wants to compute the total flux in physical units, it is useful to have the option to not normalize the integrate spectrum. I have added a positional argument in doppler.spectrum() which then can be passed to core.integrated_spectrum(). I couldn't find a way to add 'normalize' as a kwarg and not mess up the JIT, so perhaps there is a more user-friendly way to do this. 