### PR TITLE
Changing RV sign to match the rotation direction

### DIFF
--- a/spotter/core.py
+++ b/spotter/core.py
@@ -472,7 +472,7 @@ def radial_velocity(theta, phi, period, radius, phase, inc=None):
     omega = jnp.pi * 2 / period_s  # angular velocity
     radius_m = radius * 695700000.0  # convert solar radii to meters
     sin_phi = np.sin(phi)  # numpy here! as phi is static
-    rv = radius_m * omega * jnp.sin(theta - phase) * sin_phi
+    rv = radius_m * omega * jnp.sin(phase - theta) * sin_phi
     if inc is not None:
         rv = rv * jnp.sin(inc)
     return rv

--- a/tests/test_rv.py
+++ b/tests/test_rv.py
@@ -31,5 +31,5 @@ def test_jaxoplanet(deg, u):
     # import astropy.units as u
     # (1*u.m/u.s).to("R_sun/day").value
     conversion = 0.00012419146183699872
-    calc = -radial_velocity(star, phases)[0] * conversion
+    calc = radial_velocity(star, phases)[0] * conversion
     np.testing.assert_allclose(calc, expected, atol=1e-4)


### PR DESCRIPTION
The current sign of RV calculation returns redshift (positive RV value) for the hemisphere rotating towards the line of sight and vice versa. I have changed this to match the typical convention of the hemisphere rotating towards the line of sight being blueshifted (negative RV values) and vice versa. 